### PR TITLE
Fix README reference to missing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ print(torch.cuda.is_available())  # This will return True if CUDA is available
 print(torch.version.cuda)  # This will print the CUDA version being used
 print(torch.cuda.get_device_name(0))  # This will print the name of the GPU, e.g., 'NVIDIA GeForce RTX GPU Model'
 ```
-run the `get_device.py` to see if you installed it correctly 
+Run the above Python code to see if you installed it correctly 
 
 ## Cuda Requirements
 - run the `cuda-requirements.bat` after you get done with installion of nvidia.


### PR DESCRIPTION
## Summary
- remove outdated mention of `get_device.py` from the CUDA instructions in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853362bf94c8324b1240f6e5ada1c9c